### PR TITLE
fix(Bundle): missing import

### DIFF
--- a/src/TbmatukaEditorjsBundle.php
+++ b/src/TbmatukaEditorjsBundle.php
@@ -2,6 +2,7 @@
 
 namespace Tbmatuka\EditorjsBundle;
 
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Tbmatuka\EditorjsBundle\DependencyInjection\TbmatukaEditorjsExtension;
 


### PR DESCRIPTION
The recently merged PR #6 forgot to import the `ExtensionInterface` that got added as a return type to the bundles `getContainerExtension()`. 